### PR TITLE
AsyncRepository: Removed the await keywords

### DIFF
--- a/src/Infrastructure/Data/EfRepository.cs
+++ b/src/Infrastructure/Data/EfRepository.cs
@@ -90,15 +90,11 @@ namespace Microsoft.eShopWeb.Infrastructure.Data
             return entity;
         }
 
-        public Task<T> AddAsync(T entity)
+        public async Task<T> AddAsync(T entity)
         {
-            return _dbContext.Set<T>()
-                .AddAsync(entity)
-                .ContinueWith(addTask =>
-                {
-                    _dbContext.SaveChangesAsync();
-                    return addTask.Result.Entity;
-                });
+            await _dbContext.Set<T>().AddAsync(entity);
+            await _dbContext.SaveChangesAsync();
+            return entity;
         }
 
         public void Update(T entity)


### PR DESCRIPTION
I have removed the `await` keywords in the async methods of the EfRepository (according to #111).

@ardalis Can you please check especially the [AddAsync](https://github.com/dotnet-architecture/eShopOnWeb/compare/master...eluchsinger:master#diff-f3ba4deb3e276795e24b307e91f0bfbbR93) method? It required a larger change than the rest, now using the `AddAsync()` method and chaining the tasks. 