### PR TITLE
Renaming CatalogServices to CatalogViewModelService

### DIFF
--- a/src/Web/Controllers/Api/CatalogController.cs
+++ b/src/Web/Controllers/Api/CatalogController.cs
@@ -6,15 +6,15 @@ namespace Microsoft.eShopWeb.Web.Controllers.Api
 {
     public class CatalogController : BaseApiController
     {
-        private readonly ICatalogService _catalogService;
+        private readonly ICatalogViewModelService _catalogViewModelService;
 
-        public CatalogController(ICatalogService catalogService) => _catalogService = catalogService;
+        public CatalogController(ICatalogViewModelService catalogViewModelService) => _catalogViewModelService = catalogViewModelService;
 
         [HttpGet]
         public async Task<IActionResult> List(int? brandFilterApplied, int? typesFilterApplied, int? page)
         {
             var itemsPage = 10;           
-            var catalogModel = await _catalogService.GetCatalogItems(page ?? 0, itemsPage, brandFilterApplied, typesFilterApplied);
+            var catalogModel = await _catalogViewModelService.GetCatalogItems(page ?? 0, itemsPage, brandFilterApplied, typesFilterApplied);
             return Ok(catalogModel);
         }
     }

--- a/src/Web/Interfaces/ICatalogViewModelService.cs
+++ b/src/Web/Interfaces/ICatalogViewModelService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.eShopWeb.Web.Services
 {
-    public interface ICatalogService
+    public interface ICatalogViewModelService
     {
         Task<CatalogIndexViewModel> GetCatalogItems(int pageIndex, int itemsPage, int? brandId, int? typeId);
         Task<IEnumerable<SelectListItem>> GetBrands();

--- a/src/Web/Pages/Index.cshtml.cs
+++ b/src/Web/Pages/Index.cshtml.cs
@@ -7,18 +7,18 @@ namespace Microsoft.eShopWeb.Web.Pages
 {
     public class IndexModel : PageModel
     {
-        private readonly ICatalogService _catalogService;
+        private readonly ICatalogViewModelService _catalogViewModelService;
 
-        public IndexModel(ICatalogService catalogService)
+        public IndexModel(ICatalogViewModelService catalogViewModelService)
         {
-            _catalogService = catalogService;
+            _catalogViewModelService = catalogViewModelService;
         }
 
         public CatalogIndexViewModel CatalogModel { get; set; } = new CatalogIndexViewModel();
 
         public async Task OnGet(CatalogIndexViewModel catalogModel, int? pageId)
         {
-            CatalogModel = await _catalogService.GetCatalogItems(pageId ?? 0, Constants.ITEMS_PER_PAGE, catalogModel.BrandFilterApplied, catalogModel.TypesFilterApplied);
+            CatalogModel = await _catalogViewModelService.GetCatalogItems(pageId ?? 0, Constants.ITEMS_PER_PAGE, catalogModel.BrandFilterApplied, catalogModel.TypesFilterApplied);
         }
 
 

--- a/src/Web/Services/CachedCatalogViewModelService.cs
+++ b/src/Web/Services/CachedCatalogViewModelService.cs
@@ -7,20 +7,20 @@ using System;
 
 namespace Microsoft.eShopWeb.Web.Services
 {
-    public class CachedCatalogService : ICatalogService
+    public class CachedCatalogViewModelService : ICatalogViewModelService
     {
         private readonly IMemoryCache _cache;
-        private readonly CatalogService _catalogService;
+        private readonly CatalogViewModelService _catalogViewModelService;
         private static readonly string _brandsKey = "brands";
         private static readonly string _typesKey = "types";
         private static readonly string _itemsKeyTemplate = "items-{0}-{1}-{2}-{3}";
         private static readonly TimeSpan _defaultCacheDuration = TimeSpan.FromSeconds(30);
 
-        public CachedCatalogService(IMemoryCache cache,
-            CatalogService catalogService)
+        public CachedCatalogViewModelService(IMemoryCache cache,
+            CatalogViewModelService catalogViewModelService)
         {
             _cache = cache;
-            _catalogService = catalogService;
+            _catalogViewModelService = catalogViewModelService;
         }
 
         public async Task<IEnumerable<SelectListItem>> GetBrands()
@@ -28,7 +28,7 @@ namespace Microsoft.eShopWeb.Web.Services
             return await _cache.GetOrCreateAsync(_brandsKey, async entry =>
                     {
                         entry.SlidingExpiration = _defaultCacheDuration;
-                        return await _catalogService.GetBrands();
+                        return await _catalogViewModelService.GetBrands();
                     });
         }
 
@@ -38,7 +38,7 @@ namespace Microsoft.eShopWeb.Web.Services
             return await _cache.GetOrCreateAsync(cacheKey, async entry =>
             {
                 entry.SlidingExpiration = _defaultCacheDuration;
-                return await _catalogService.GetCatalogItems(pageIndex, itemsPage, brandId, typeId);
+                return await _catalogViewModelService.GetCatalogItems(pageIndex, itemsPage, brandId, typeId);
             });
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.eShopWeb.Web.Services
             return await _cache.GetOrCreateAsync(_typesKey, async entry =>
             {
                 entry.SlidingExpiration = _defaultCacheDuration;
-                return await _catalogService.GetTypes();
+                return await _catalogViewModelService.GetTypes();
             });
         }
     }

--- a/src/Web/Services/CatalogViewModelService.cs
+++ b/src/Web/Services/CatalogViewModelService.cs
@@ -15,22 +15,22 @@ namespace Microsoft.eShopWeb.Web.Services
     /// This is a UI-specific service so belongs in UI project. It does not contain any business logic and works
     /// with UI-specific types (view models and SelectListItem types).
     /// </summary>
-    public class CatalogService : ICatalogService
+    public class CatalogViewModelService : ICatalogViewModelService
     {
-        private readonly ILogger<CatalogService> _logger;
+        private readonly ILogger<CatalogViewModelService> _logger;
         private readonly IAsyncRepository<CatalogItem> _itemRepository;
         private readonly IAsyncRepository<CatalogBrand> _brandRepository;
         private readonly IAsyncRepository<CatalogType> _typeRepository;
         private readonly IUriComposer _uriComposer;
 
-        public CatalogService(
+        public CatalogViewModelService(
             ILoggerFactory loggerFactory,
             IAsyncRepository<CatalogItem> itemRepository,
             IAsyncRepository<CatalogBrand> brandRepository,
             IAsyncRepository<CatalogType> typeRepository,
             IUriComposer uriComposer)
         {
-            _logger = loggerFactory.CreateLogger<CatalogService>();
+            _logger = loggerFactory.CreateLogger<CatalogViewModelService>();
             _itemRepository = itemRepository;
             _brandRepository = brandRepository;
             _typeRepository = typeRepository;

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -87,12 +87,12 @@ namespace Microsoft.eShopWeb.Web
             
             services.AddScoped(typeof(IAsyncRepository<>), typeof(EfRepository<>));
 
-            services.AddScoped<ICatalogService, CachedCatalogService>();
+            services.AddScoped<ICatalogViewModelService, CachedCatalogViewModelService>();
             services.AddScoped<IBasketService, BasketService>();
             services.AddScoped<IBasketViewModelService, BasketViewModelService>();
             services.AddScoped<IOrderService, OrderService>();
             services.AddScoped<IOrderRepository, OrderRepository>();
-            services.AddScoped<CatalogService>();
+            services.AddScoped<CatalogViewModelService>();
             services.Configure<CatalogSettings>(Configuration);
             services.AddSingleton<IUriComposer>(new UriComposer(Configuration.Get<CatalogSettings>()));
 


### PR DESCRIPTION
- I believe this causes some confusion when people see "Service" in the Web project. We have another service in there named BasketViewModelService instead of BasketService anyways. Adding "ViewModel" to the name is a better representation of what the "services" in the Web project represent.