### PR TITLE
Update EmailSenderExtensions.cs

### DIFF
--- a/src/Web/Extensions/EmailSenderExtensions.cs
+++ b/src/Web/Extensions/EmailSenderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace Microsoft.eShopWeb.Web.Services
 {
@@ -9,7 +10,7 @@ namespace Microsoft.eShopWeb.Web.Services
         public static Task SendEmailConfirmationAsync(this IEmailSender emailSender, string email, string link)
         {
             return emailSender.SendEmailAsync(email, "Confirm your email",
-                $"Please confirm your account by clicking this link: <a href='{HtmlEncoder.Default.Encode(link)}'>link</a>");
+                $"Please confirm your account by clicking this link: <a href='{HttpUtility.UrlPathEncode(link)}'>link</a>");
         }
     }
 }


### PR DESCRIPTION
Could be my ignorance, but this code did not work for me when the link had parameters separated by ampersands. This proposed change solved the problem for me, and then I went (curious) to see if I could find where this code snippet had come from. And here I am... thought I'd share my findings. Apologies if I'm mistaken and this proposed change is not an improvement.