### PR TITLE
Removing marker interface

### DIFF
--- a/src/ApplicationCore/Attributes/AggregateRootAttribute.cs
+++ b/src/ApplicationCore/Attributes/AggregateRootAttribute.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace Microsoft.eShopWeb.ApplicationCore.Attributes
+{
+    internal class AggregateRootAttribute : Attribute
+    {
+    }
+}

--- a/src/ApplicationCore/Entities/BasketAggregate/Basket.cs
+++ b/src/ApplicationCore/Entities/BasketAggregate/Basket.cs
@@ -1,10 +1,12 @@
-﻿using Microsoft.eShopWeb.ApplicationCore.Interfaces;
+﻿using Microsoft.eShopWeb.ApplicationCore.Attributes;
+using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using System.Collections.Generic;
 using System.Linq;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate
 {
-    public class Basket : BaseEntity, IAggregateRoot
+    [AggregateRoot]
+    public class Basket : BaseEntity
     {
         public string BuyerId { get; set; }
         private readonly List<BasketItem> _items = new List<BasketItem>();

--- a/src/ApplicationCore/Entities/BuyerAggregate/Buyer.cs
+++ b/src/ApplicationCore/Entities/BuyerAggregate/Buyer.cs
@@ -1,10 +1,12 @@
 ﻿using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using Ardalis.GuardClauses;
 using System.Collections.Generic;
+using Microsoft.eShopWeb.ApplicationCore.Attributes;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Entities.BuyerAggregate
 {
-    public class Buyer : BaseEntity, IAggregateRoot
+    [AggregateRoot]
+    public class Buyer : BaseEntity
     {
         public string IdentityGuid { get; private set; }
 

--- a/src/ApplicationCore/Entities/OrderAggregate/Order.cs
+++ b/src/ApplicationCore/Entities/OrderAggregate/Order.cs
@@ -2,10 +2,12 @@
 using Ardalis.GuardClauses;
 using System;
 using System.Collections.Generic;
+using Microsoft.eShopWeb.ApplicationCore.Attributes;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Entities.OrderAggregate
 {
-    public class Order : BaseEntity, IAggregateRoot
+    [AggregateRoot]
+    public class Order : BaseEntity
     {
         private Order()
         {

--- a/src/ApplicationCore/Interfaces/IAggregateRoot.cs
+++ b/src/ApplicationCore/Interfaces/IAggregateRoot.cs
@@ -1,5 +1,0 @@
-﻿namespace Microsoft.eShopWeb.ApplicationCore.Interfaces
-{
-    public interface IAggregateRoot
-    { }
-}


### PR DESCRIPTION
Hi! It's me again with another trivial change :)
This time I've noticed that `IAggreagateRoot` is just an example of [marker interface](https://stackoverflow.com/questions/2086451/compelling-reasons-to-use-marker-interfaces-instead-of-attributes).
Looks like it carries pure declarative purpose and inheritance is the thing we should apply with care. So in case, you can't name some reasons to use a marker interface instead you can take advantage of my humble PR.
I hope you're having a good day
Regards
Bohdan.