### PR TITLE
Remove references to "Microsoft.EntityFrameworkCore.*" in eShopOnWeb.ApplicationCore

### DIFF
--- a/src/ApplicationCore/ApplicationCore.csproj
+++ b/src/ApplicationCore/ApplicationCore.csproj
@@ -7,7 +7,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Ardalis.GuardClauses" Version="1.2.9" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Abstractions" Version="2.2.6" />
 		<PackageReference Include="System.Security.Claims" Version="4.3.0" />
 	</ItemGroup>
 

--- a/src/ApplicationCore/Entities/OrderAggregate/Address.cs
+++ b/src/ApplicationCore/Entities/OrderAggregate/Address.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
-using System;
+﻿using System;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Entities.OrderAggregate
 {

--- a/src/ApplicationCore/Entities/OrderAggregate/CatalogItemOrdered.cs
+++ b/src/ApplicationCore/Entities/OrderAggregate/CatalogItemOrdered.cs
@@ -1,5 +1,4 @@
 ﻿using Ardalis.GuardClauses;
-using Microsoft.EntityFrameworkCore;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Entities.OrderAggregate
 {


### PR DESCRIPTION
Remove references to namespace "Microsoft.EntityFrameworkCore.*" in order to remove dependencies to EF Core in project eShopOnWeb.ApplicationCore. Remove any packages related to EF Core from ApplicationCore.csproj.