### PR TITLE
Removing https from override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,14 +1,11 @@
 version: '3.4'
-
 services:
-  eshopwebmvc:
-    environment:
-      - ASPNETCORE_ENVIRONMENT=Development
-      - ASPNETCORE_URLS=https://+:443;http://+:80
-      - ASPNETCORE_HTTPS_PORT=5443
-    ports:
-      - "5106:80"
-      - "5443:443"
-    volumes:
-      - ~/.aspnet/https:/root/.aspnet/https:ro
-      - ~/.microsoft/usersecrets:/root/.microsoft/usersecrets:ro
+ eshopwebmvc:
+   environment:
+     - ASPNETCORE_ENVIRONMENT=Development
+     - ASPNETCORE_URLS=http://+:80
+   ports:
+     - "5106:80"
+   volumes:
+     - ~/.aspnet/https:/root/.aspnet/https:ro
+     - ~/.microsoft/usersecrets:/root/.microsoft/usersecrets:ro


### PR DESCRIPTION
- There are issues with generating a local cert when trying to run this project from the docker-compose at the moment. Removing the https bits for now until so the docker-compose will work right after cloning the project.