### PR TITLE
Throw error if someone tries to add more than 3 of the same item

### DIFF
--- a/src/ApplicationCore/Exceptions/BasketLogicException.cs
+++ b/src/ApplicationCore/Exceptions/BasketLogicException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Microsoft.eShopWeb.ApplicationCore.Exceptions
+{
+    public class BasketLogicException : Exception
+    {
+        public BasketLogicException(int maxNumberOfItems)
+            : base($"{nameof(BasketLogicException)} - cannot have more than {maxNumberOfItems} of the same type of item in the basket. Basket not updated.")
+        {
+        }
+
+        protected BasketLogicException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+        }
+
+        public BasketLogicException(string message) : base(message)
+        {
+        }
+
+        public BasketLogicException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/ApplicationCore/Exceptions/BasketLogicExceptions/BasketLogicException.cs
+++ b/src/ApplicationCore/Exceptions/BasketLogicExceptions/BasketLogicException.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 
-namespace Microsoft.eShopWeb.ApplicationCore.Exceptions
+namespace Microsoft.eShopWeb.ApplicationCore.Exceptions.BasketLogicExceptions
 {
     public class BasketLogicException : Exception
     {
-        public BasketLogicException(int maxNumberOfItems)
-            : base($"{nameof(BasketLogicException)} - cannot have more than {maxNumberOfItems} of the same type of item in the basket. Basket not updated.")
+        public BasketLogicException()
+            : base($"A {nameof(BasketLogicException)} was thrown.")
         {
         }
 

--- a/src/ApplicationCore/Exceptions/BasketLogicExceptions/TooManyOfItemInBasketException.cs
+++ b/src/ApplicationCore/Exceptions/BasketLogicExceptions/TooManyOfItemInBasketException.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Microsoft.eShopWeb.ApplicationCore.Exceptions.BasketLogicExceptions
+{
+    public class TooManyOfItemInBasketException : BasketLogicException
+    {
+        public TooManyOfItemInBasketException(int maxNumberOfItems)
+            : base($"{nameof(BasketLogicException)} - cannot have more than {maxNumberOfItems} of the same type of item in the basket. Basket not updated.")
+        {
+        }
+
+        protected TooManyOfItemInBasketException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
+        {
+        }
+
+        public TooManyOfItemInBasketException(string message) : base(message)
+        {
+        }
+
+        public TooManyOfItemInBasketException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/src/ApplicationCore/Exceptions/GuardExtensions.cs
+++ b/src/ApplicationCore/Exceptions/GuardExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.eShopWeb.ApplicationCore.Exceptions;
 using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
+using Microsoft.eShopWeb.ApplicationCore.Exceptions.BasketLogicExceptions;
 
 namespace Ardalis.GuardClauses
 {
@@ -9,6 +10,12 @@ namespace Ardalis.GuardClauses
         {
             if (basket == null)
                 throw new BasketNotFoundException(basketId);
+        }
+
+        public static void TooManyOfItemInBasket(this IGuardClause guardClause, int maxNumberOfItem, int numberOfItemDesired)
+        {
+            if (numberOfItemDesired > maxNumberOfItem)
+                throw new TooManyOfItemInBasketException(maxNumberOfItem);
         }
     }
 }

--- a/src/ApplicationCore/Services/BasketService.cs
+++ b/src/ApplicationCore/Services/BasketService.cs
@@ -5,7 +5,7 @@ using Microsoft.eShopWeb.ApplicationCore.Specifications;
 using System.Linq;
 using Ardalis.GuardClauses;
 using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
-using System;
+using Microsoft.eShopWeb.ApplicationCore.Exceptions;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Services
 {
@@ -55,16 +55,19 @@ namespace Microsoft.eShopWeb.ApplicationCore.Services
         {
             Guard.Against.Null(quantities, nameof(quantities));
             var basket = await _basketRepository.GetByIdAsync(basketId);
+            var maxNumberOfUniqueItem = 3;
+
             Guard.Against.NullBasket(basketId, basket);
 
             foreach (var item in basket.Items)
             {
                 if (quantities.TryGetValue(item.Id.ToString(), out var quantity))
                 {
-                    if (quantity > 3)
+                    if (quantity > maxNumberOfUniqueItem)
                     {
-                        throw new InvalidOperationException("Business Rule - you may not have more than 3 of the same item in your basket!");
+                        throw new BasketLogicException(maxNumberOfUniqueItem);
                     }
+
                     if(_logger != null) _logger.LogInformation($"Updating quantity of item ID:{item.Id} to {quantity}.");
                     item.Quantity = quantity;
                 }

--- a/src/ApplicationCore/Services/BasketService.cs
+++ b/src/ApplicationCore/Services/BasketService.cs
@@ -5,6 +5,7 @@ using Microsoft.eShopWeb.ApplicationCore.Specifications;
 using System.Linq;
 using Ardalis.GuardClauses;
 using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
+using System;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Services
 {
@@ -55,10 +56,15 @@ namespace Microsoft.eShopWeb.ApplicationCore.Services
             Guard.Against.Null(quantities, nameof(quantities));
             var basket = await _basketRepository.GetByIdAsync(basketId);
             Guard.Against.NullBasket(basketId, basket);
+
             foreach (var item in basket.Items)
             {
                 if (quantities.TryGetValue(item.Id.ToString(), out var quantity))
                 {
+                    if (quantity > 3)
+                    {
+                        throw new InvalidOperationException("Business Rule - you may not have more than 3 of the same item in your basket!");
+                    }
                     if(_logger != null) _logger.LogInformation($"Updating quantity of item ID:{item.Id} to {quantity}.");
                     item.Quantity = quantity;
                 }

--- a/src/ApplicationCore/Services/BasketService.cs
+++ b/src/ApplicationCore/Services/BasketService.cs
@@ -5,7 +5,7 @@ using Microsoft.eShopWeb.ApplicationCore.Specifications;
 using System.Linq;
 using Ardalis.GuardClauses;
 using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
-using Microsoft.eShopWeb.ApplicationCore.Exceptions;
+using Microsoft.eShopWeb.ApplicationCore.Exceptions.BasketLogicExceptions;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Services
 {
@@ -65,7 +65,7 @@ namespace Microsoft.eShopWeb.ApplicationCore.Services
                 {
                     if (quantity > maxNumberOfUniqueItem)
                     {
-                        throw new BasketLogicException(maxNumberOfUniqueItem);
+                        throw new TooManyOfItemInBasketException(maxNumberOfUniqueItem);
                     }
 
                     if(_logger != null) _logger.LogInformation($"Updating quantity of item ID:{item.Id} to {quantity}.");

--- a/src/ApplicationCore/Services/BasketService.cs
+++ b/src/ApplicationCore/Services/BasketService.cs
@@ -63,12 +63,15 @@ namespace Microsoft.eShopWeb.ApplicationCore.Services
             {
                 if (quantities.TryGetValue(item.Id.ToString(), out var quantity))
                 {
-                    if (quantity > maxNumberOfUniqueItem)
-                    {
-                        throw new TooManyOfItemInBasketException(maxNumberOfUniqueItem);
-                    }
+                    Guard.Against.TooManyOfItemInBasket(maxNumberOfUniqueItem, quantity);
 
-                    if(_logger != null) _logger.LogInformation($"Updating quantity of item ID:{item.Id} to {quantity}.");
+                    //Leaving the below if statement commented out to show what you can reduce it to w/ the above line
+                    //if (quantity > maxNumberOfUniqueItem)
+                    //{
+                    //    throw new TooManyOfItemInBasketException(maxNumberOfUniqueItem);
+                    //}
+
+                    if (_logger != null) _logger.LogInformation($"Updating quantity of item ID:{item.Id} to {quantity}.");
                     item.Quantity = quantity;
                 }
             }

--- a/src/Web/Pages/Basket/BasketViewModel.cs
+++ b/src/Web/Pages/Basket/BasketViewModel.cs
@@ -14,5 +14,7 @@ namespace Microsoft.eShopWeb.Web.Pages.Basket
         {
             return Math.Round(Items.Sum(x => x.UnitPrice * x.Quantity), 2);
         }
+
+        public string ErrorMessage { get; set; }
     }
 }

--- a/src/Web/Pages/Basket/Index.cshtml
+++ b/src/Web/Pages/Basket/Index.cshtml
@@ -48,7 +48,10 @@
             </div>*@
 
                 }
-
+                @if (!string.IsNullOrEmpty(Model.BasketModel.ErrorMessage))
+                {
+                    <div>@Model.BasketModel.ErrorMessage</div>
+                }
                 <div class="container">
                     <article class="esh-basket-titles esh-basket-titles--clean row">
                         <section class="esh-basket-title col-xs-10"></section>

--- a/src/Web/Pages/Basket/Index.cshtml.cs
+++ b/src/Web/Pages/Basket/Index.cshtml.cs
@@ -57,9 +57,20 @@ namespace Microsoft.eShopWeb.Web.Pages.Basket
         public async Task OnPostUpdate(Dictionary<string, int> items)
         {
             await SetBasketModelAsync();
-            await _basketService.SetQuantities(BasketModel.Id, items);
 
-            await SetBasketModelAsync();
+            try
+            {
+                await _basketService.SetQuantities(BasketModel.Id, items);
+                await SetBasketModelAsync();
+            }
+            catch (InvalidOperationException ex)
+            {
+                BasketModel.ErrorMessage = ex.Message;
+            }
+            catch (Exception)
+            {
+                BasketModel.ErrorMessage = "Something we weren't expecting happened.";
+            }
         }
 
         private async Task SetBasketModelAsync()

--- a/src/Web/Pages/Basket/Index.cshtml.cs
+++ b/src/Web/Pages/Basket/Index.cshtml.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.eShopWeb.ApplicationCore.Exceptions;
 using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using Microsoft.eShopWeb.Infrastructure.Identity;
 using Microsoft.eShopWeb.Web.Interfaces;
@@ -63,7 +64,7 @@ namespace Microsoft.eShopWeb.Web.Pages.Basket
                 await _basketService.SetQuantities(BasketModel.Id, items);
                 await SetBasketModelAsync();
             }
-            catch (InvalidOperationException ex)
+            catch (BasketLogicException ex)
             {
                 BasketModel.ErrorMessage = ex.Message;
             }

--- a/src/Web/Pages/Basket/Index.cshtml.cs
+++ b/src/Web/Pages/Basket/Index.cshtml.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.eShopWeb.ApplicationCore.Exceptions;
+using Microsoft.eShopWeb.ApplicationCore.Exceptions.BasketLogicExceptions;
 using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using Microsoft.eShopWeb.Infrastructure.Identity;
 using Microsoft.eShopWeb.Web.Interfaces;


### PR DESCRIPTION
This is a quick example of a way to bubble up an error that was thrown by a service in ApplicationCore (or the business logic).

Just for an example, the business gave us a rule that a customer cannot add more than 3 of the same item to their cart. Since this logic should not be in the Web project, it lives in the `BasketService`. 

- In the `BasketService` we will throw an `InvalidOperationException` when the input breaks the business rule
- In the Controller we then put a try/catch around the existing call and catch the specific exception
- We then need to display something to the user when that specific exception had been caught, so we can add an `ErrorMessage` property to the ViewModel
- When we catch the exception, we can set the `ErrorMessage` value, and if there is a value present, we can display that to the user on the frontend indicating what went wrong.

Steps to see the error:
- Login with the demo user
- Add an item to your cart
- Navigate to the cart
- Try to update the quantity of the item to 4 or more
- You should see a new message display at the bottom indicating that an error occurred
![image](https://user-images.githubusercontent.com/1899987/65823855-0f05fd80-e22c-11e9-9620-9374c7cf6d12.png)
