### PR TITLE
Update database instructions to work in .NET Core 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ You can also run the samples in Docker (see below).
 
 ```
 dotnet restore
+dotnet tool restore
 dotnet ef database update -c catalogcontext -p ../Infrastructure/Infrastructure.csproj -s Web.csproj
 dotnet ef database update -c appidentitydbcontext -p ../Infrastructure/Infrastructure.csproj -s Web.csproj
 ```

--- a/src/Web/.config/dotnet-tools.json
+++ b/src/Web/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "3.0.0",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
In the 3.0 SDK `dotnet ef` needs to be installed. This updates the instructions/tool config to do so.

More info: https://docs.microsoft.com/en-us/ef/core/miscellaneous/cli/dotnet