### PR TITLE
Edit Include to ThenInclude

### DIFF
--- a/src/Infrastructure/Data/OrderRepository.cs
+++ b/src/Infrastructure/Data/OrderRepository.cs
@@ -15,7 +15,7 @@ namespace Microsoft.eShopWeb.Infrastructure.Data
         {
             return _dbContext.Orders
                 .Include(o => o.OrderItems)
-                .Include($"{nameof(Order.OrderItems)}.{nameof(OrderItem.ItemOrdered)}")
+                .ThenInclude(i => i.ItemOrdered)
                 .FirstOrDefaultAsync(x => x.Id == id);
         }
     }


### PR DESCRIPTION
I edited Include to ThenInclude in OrderRepository since we are using EF Core, we can make the code more readable.

### Old code
``` CS
.Include($"{nameof(Order.OrderItems)}.{nameof(OrderItem.ItemOrdered)}")
```

### New code
``` CS
.ThenInclude(i => i.ItemOrdered)
```