### PR TITLE
Specific health checks implementations registered into the application

### DIFF
--- a/src/Web/HealthChecks/ApiHealthCheck.cs
+++ b/src/Web/HealthChecks/ApiHealthCheck.cs
@@ -1,31 +1,25 @@
 ﻿using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
+using BlazorShared;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.eShopWeb.Web.HealthChecks;
 
 public class ApiHealthCheck : IHealthCheck
 {
-    private readonly IHttpContextAccessor _httpContextAccessor;
-    private readonly LinkGenerator _linkGenerator;
+    private readonly BaseUrlConfiguration _baseUrlConfiguration;
 
-    public ApiHealthCheck(IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+    public ApiHealthCheck(BaseUrlConfiguration baseUrlConfiguration)
     {
-        _httpContextAccessor = httpContextAccessor;
-        _linkGenerator = linkGenerator;
+        _baseUrlConfiguration = baseUrlConfiguration;
     }
 
     public async Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default(CancellationToken))
     {
-        var request = _httpContextAccessor.HttpContext.Request;
-
-        string apiLink = _linkGenerator.GetPathByAction("List", "Catalog");
-        string myUrl = request.Scheme + "://" + request.Host.ToString() + apiLink;
+        string myUrl = _baseUrlConfiguration.ApiBase + "catalog-items";
         var client = new HttpClient();
         var response = await client.GetAsync(myUrl);
         var pageContents = await response.Content.ReadAsStringAsync();

--- a/src/Web/Startup.cs
+++ b/src/Web/Startup.cs
@@ -22,6 +22,7 @@ using Microsoft.eShopWeb.ApplicationCore.Interfaces;
 using Microsoft.eShopWeb.Infrastructure.Data;
 using Microsoft.eShopWeb.Infrastructure.Identity;
 using Microsoft.eShopWeb.Web.Configuration;
+using Microsoft.eShopWeb.Web.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -136,7 +137,10 @@ public class Startup
             options.Conventions.AuthorizePage("/Basket/Checkout");
         });
         services.AddHttpContextAccessor();
-        services.AddHealthChecks();
+        services
+            .AddHealthChecks()
+            .AddCheck<ApiHealthCheck>("api_health_check", tags: new[] { "apiHealthCheck" })
+            .AddCheck<HomePageHealthCheck>("home_page_health_check", tags: new[] { "homePageHealthCheck" });
         services.Configure<ServiceConfig>(config =>
         {
             config.Services = new List<ServiceDescriptor>(services);
@@ -227,8 +231,8 @@ public class Startup
         {
             endpoints.MapControllerRoute("default", "{controller:slugify=Home}/{action:slugify=Index}/{id?}");
             endpoints.MapRazorPages();
-            endpoints.MapHealthChecks("home_page_health_check");
-            endpoints.MapHealthChecks("api_health_check");
+            endpoints.MapHealthChecks("home_page_health_check", new HealthCheckOptions { Predicate = check => check.Tags.Contains("homePageHealthCheck") });
+            endpoints.MapHealthChecks("api_health_check", new HealthCheckOptions { Predicate = check => check.Tags.Contains("apiHealthCheck") });
                 //endpoints.MapBlazorHub("/admin");
                 endpoints.MapFallbackToFile("index.html");
         });


### PR DESCRIPTION
Health checks in the current version are not registered. Also, the API health check had the wrong URL. 
I presume that API and Home check are separated so I've create also specific tags. The main `/health` endpoint still catches all of it.