### PR TITLE
Add exception rethrow to ExceptionMiddleware.cs in PublicApi project

### DIFF
--- a/src/PublicApi/Middleware/ExceptionMiddleware.cs
+++ b/src/PublicApi/Middleware/ExceptionMiddleware.cs
@@ -25,6 +25,7 @@ public class ExceptionMiddleware
         catch (Exception ex)
         {
             await HandleExceptionAsync(httpContext, ex);
+            throw;
         }
     }
 


### PR DESCRIPTION
While I was testing endpoints in PublicApi project I noticed that even if an exception is thrown api will return StatusCode 200.
During further investigation I discored that 'ExceptionMiddleware' consumes all exception, but it handels only 'DuplicateException' and it does not rethrow any other exception.

This one-line PR fixes the issue by  adding 'throw;' to mentioned middleware.