### PR TITLE
Make docker work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     ports:
       - "1433:1433"
     environment:
-      - SA_PASSWORD=${SA_PASSWORD}
+      - SA_PASSWORD=KT!D7?8B2@someThingComplicated1234
       - ACCEPT_EULA=Y
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,6 @@ services:
     ports:
       - "1433:1433"
     environment:
-      - SA_PASSWORD=KT!D7?8B2@someThingComplicated1234
+      - SA_PASSWORD=@someThingComplicated1234
       - ACCEPT_EULA=Y
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,20 @@ services:
     build:
       context: .
       dockerfile: src/Web/Dockerfile
+    depends_on:
+      - "sqlserver"
   eshoppublicapi:
     image: ${DOCKER_REGISTRY-}eshoppublicapi
     build:
       context: .
       dockerfile: src/PublicApi/Dockerfile
+    depends_on:
+      - "sqlserver"
+  sqlserver:
+    image: mcr.microsoft.com/azure-sql-edge
+    ports:
+      - "1433:1433"
+    environment:
+      - SA_PASSWORD=${SA_PASSWORD}
+      - ACCEPT_EULA=Y
 

--- a/src/PublicApi/appsettings.Docker.json
+++ b/src/PublicApi/appsettings.Docker.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "CatalogConnection": "Server=(localdb)\\mssqllocaldb;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;",
-    "IdentityConnection": "Server=(localdb)\\mssqllocaldb;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;"
+    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;",
+    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;"
   },
   "baseUrls": {
     "apiBase": "http://localhost:5200/api/",

--- a/src/PublicApi/appsettings.Docker.json
+++ b/src/PublicApi/appsettings.Docker.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;",
-    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;"
+    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=KT!D7?8B2@someThingComplicated1234;Trusted_Connection=false;",
+    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=KT!D7?8B2@someThingComplicated1234;Trusted_Connection=false;"
   },
   "baseUrls": {
     "apiBase": "http://localhost:5200/api/",

--- a/src/PublicApi/appsettings.Docker.json
+++ b/src/PublicApi/appsettings.Docker.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=KT!D7?8B2@someThingComplicated1234;Trusted_Connection=false;",
-    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=KT!D7?8B2@someThingComplicated1234;Trusted_Connection=false;"
+    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;",
+    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;"
   },
   "baseUrls": {
     "apiBase": "http://localhost:5200/api/",

--- a/src/Web/appsettings.Docker.json
+++ b/src/Web/appsettings.Docker.json
@@ -1,7 +1,7 @@
 {
   "ConnectionStrings": {
-    "CatalogConnection": "Server=(localdb)\\mssqllocaldb;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;",
-    "IdentityConnection": "Server=(localdb)\\mssqllocaldb;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;"
+    "CatalogConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.CatalogDb;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;",
+    "IdentityConnection": "Server=sqlserver,1433;Integrated Security=true;Initial Catalog=Microsoft.eShopOnWeb.Identity;User Id=sa;Password=@someThingComplicated1234;Trusted_Connection=false;"
   },
   "baseUrls": {
     "apiBase": "http://localhost:5200/api/",


### PR DESCRIPTION
Trying to run the eShopOnWeb project using the Docker instructions failed, both on Windows 11 and an M1 Macbook. 
This PR fixes this and makes it work on both platforms. 
LocalDB support was missing for M1 and the Docker version I installed in Windows 11, so I added a separate container for the SQL server and made the Web and Public API point to it. 