### PR TITLE
Fix issue 654 caused by "Null Reference Types" which was enabled when the…

### DIFF
--- a/src/Web/Pages/Basket/BasketItemViewModel.cs
+++ b/src/Web/Pages/Basket/BasketItemViewModel.cs
@@ -6,12 +6,12 @@ public class BasketItemViewModel
 {
     public int Id { get; set; }
     public int CatalogItemId { get; set; }
-    public string ProductName { get; set; }
+    public string? ProductName { get; set; }
     public decimal UnitPrice { get; set; }
     public decimal OldUnitPrice { get; set; }
 
     [Range(0, int.MaxValue, ErrorMessage = "Quantity must be bigger than 0")]
     public int Quantity { get; set; }
 
-    public string PictureUrl { get; set; }
+    public string? PictureUrl { get; set; }
 }


### PR DESCRIPTION
… project was upgraded to .NET 6.

Null Reference Types is a group of features introduced in C# 8 to prevent Null Reference exceptions. This features are enabled by default on .NET 6 projects, more informaiton about it here: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references