### PR TITLE
Fix issue #660 (null reference issue)

### DIFF
--- a/src/Web/Web.csproj
+++ b/src/Web/Web.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <Nullable>disable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <RootNamespace>Microsoft.eShopWeb.Web</RootNamespace>
     <UserSecretsId>aspnet-Web2-1FA3F72E-E7E3-4360-9E49-1CCCD7FE85F7</UserSecretsId>


### PR DESCRIPTION
Null reference type is enabled by default in the web project, which causes model validation failure in some pages and broke the site.

In this PR, I have disabled nullabe annotations in the web project. If this PR is excepted and merged to the main branch, do not need to merge the other two PR (#655 & #659 ).  