### PR TITLE
Fix Multiple DbContext Registration

### DIFF
--- a/tests/FunctionalTests/Web/WebTestFixture.cs
+++ b/tests/FunctionalTests/Web/WebTestFixture.cs
@@ -23,6 +23,16 @@ public class TestApplication : WebApplicationFactory<IBasketViewModelService>
         // Add mock/test services to the builder here
         builder.ConfigureServices(services =>
         {
+            var descriptors = services.Where(d =>
+                                                d.ServiceType == typeof(DbContextOptions<CatalogContext>) ||
+                                                d.ServiceType == typeof(DbContextOptions<AppIdentityDbContext>))
+                                            .ToList();
+
+            foreach (var descriptor in descriptors)
+            {
+                services.Remove(descriptor);
+            }
+
             services.AddScoped(sp =>
             {
                 // Replace SQLite with in-memory database for tests


### PR DESCRIPTION
Hi, i noticed that in the _WebTestFixture_ used for _FunctionalTests_ the **DbContexts** were registered without removing the existing ones in _Program.cs_ which leads to duplication