### PR TITLE
Removed redundant ternary

### DIFF
--- a/src/Web/Controllers/UserController.cs
+++ b/src/Web/Controllers/UserController.cs
@@ -24,7 +24,7 @@ public class UserController : ControllerBase
     [Authorize]
     [AllowAnonymous]
     public async Task<IActionResult> GetCurrentUser() =>
-        Ok(User.Identity.IsAuthenticated ? await CreateUserInfo(User) : UserInfo.Anonymous);
+        Ok(await CreateUserInfo(User));
 
     private async Task<UserInfo> CreateUserInfo(ClaimsPrincipal claimsPrincipal)
     {


### PR DESCRIPTION
This check for `User.Identity.IsAuthenticated` is performed inside `CreateUserInfo` so there is no need to do it in `GetCurrentUser`