### PR TITLE
Reduce build warnings by half

### DIFF
--- a/src/Web/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/src/Web/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -24,24 +24,24 @@ public class LoginModel : PageModel
     }
 
     [BindProperty]
-    public InputModel Input { get; set; }
+    public InputModel? Input { get; set; }
 
-    public IList<AuthenticationScheme> ExternalLogins { get; set; }
+    public IList<AuthenticationScheme>? ExternalLogins { get; set; }
 
-    public string ReturnUrl { get; set; }
+    public string? ReturnUrl { get; set; }
 
     [TempData]
-    public string ErrorMessage { get; set; }
+    public string? ErrorMessage { get; set; }
 
     public class InputModel
     {
         [Required]
         [EmailAddress]
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         [Required]
         [DataType(DataType.Password)]
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
         [Display(Name = "Remember me?")]
         public bool RememberMe { get; set; }
@@ -101,7 +101,7 @@ public class LoginModel : PageModel
         return Page();
     }
 
-    private async Task TransferAnonymousBasketToUserAsync(string userName)
+    private async Task TransferAnonymousBasketToUserAsync(string? userName)
     {
         if (Request.Cookies.ContainsKey(Constants.BASKET_COOKIENAME))
         {

--- a/src/Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
+++ b/src/Web/Areas/Identity/Pages/Account/Logout.cshtml.cs
@@ -32,7 +32,7 @@ public class LogoutModel : PageModel
     {
     }
 
-    public async Task<IActionResult> OnPost(string returnUrl = null)
+    public async Task<IActionResult> OnPost(string? returnUrl = null)
     {
         await _signInManager.SignOutAsync();
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);

--- a/src/Web/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/src/Web/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -34,35 +34,35 @@ public class RegisterModel : PageModel
     }
 
     [BindProperty]
-    public InputModel Input { get; set; }
+    public InputModel? Input { get; set; }
 
-    public string ReturnUrl { get; set; }
+    public string? ReturnUrl { get; set; }
 
     public class InputModel
     {
         [Required]
         [EmailAddress]
         [Display(Name = "Email")]
-        public string Email { get; set; }
+        public string? Email { get; set; }
 
         [Required]
         [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
         [DataType(DataType.Password)]
         [Display(Name = "Password")]
-        public string Password { get; set; }
+        public string? Password { get; set; }
 
         [DataType(DataType.Password)]
         [Display(Name = "Confirm password")]
         [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
-        public string ConfirmPassword { get; set; }
+        public string? ConfirmPassword { get; set; }
     }
 
-    public void OnGet(string returnUrl = null)
+    public void OnGet(string? returnUrl = null)
     {
         ReturnUrl = returnUrl;
     }
 
-    public async Task<IActionResult> OnPostAsync(string returnUrl = null)
+    public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
     {
         returnUrl = returnUrl ?? Url.Content("~/");
         if (ModelState.IsValid)

--- a/src/Web/Controllers/ManageController.cs
+++ b/src/Web/Controllers/ManageController.cs
@@ -40,7 +40,7 @@ public class ManageController : Controller
     }
 
     [TempData]
-    public string StatusMessage { get; set; }
+    public string? StatusMessage { get; set; }
 
     [HttpGet]
     public async Task<IActionResult> MyAccount()
@@ -377,7 +377,7 @@ public class ManageController : Controller
     [HttpGet]
     public IActionResult ShowRecoveryCodes()
     {
-        var recoveryCodes = (string[])TempData[RecoveryCodesKey];
+        var recoveryCodes = (string[]?)TempData[RecoveryCodesKey];
         if (recoveryCodes == null)
         {
             return RedirectToAction(nameof(TwoFactorAuthentication));

--- a/src/Web/Pages/Basket/BasketViewModel.cs
+++ b/src/Web/Pages/Basket/BasketViewModel.cs
@@ -4,7 +4,7 @@ public class BasketViewModel
 {
     public int Id { get; set; }
     public List<BasketItemViewModel> Items { get; set; } = new List<BasketItemViewModel>();
-    public string BuyerId { get; set; }
+    public string? BuyerId { get; set; }
 
     public decimal Total()
     {

--- a/src/Web/Pages/Basket/Checkout.cshtml.cs
+++ b/src/Web/Pages/Basket/Checkout.cshtml.cs
@@ -16,7 +16,7 @@ public class CheckoutModel : PageModel
     private readonly IBasketService _basketService;
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IOrderService _orderService;
-    private string _username = null;
+    private string? _username = null;
     private readonly IBasketViewModelService _basketViewModelService;
     private readonly IAppLogger<CheckoutModel> _logger;
 

--- a/src/Web/Pages/Basket/Index.cshtml.cs
+++ b/src/Web/Pages/Basket/Index.cshtml.cs
@@ -66,7 +66,7 @@ public class IndexModel : PageModel
 
     private string GetOrSetBasketCookieAndUserName()
     {
-        string userName = null;
+        string? userName = null;
 
         if (Request.HttpContext.User.Identity.IsAuthenticated)
         {

--- a/src/Web/Pages/Error.cshtml.cs
+++ b/src/Web/Pages/Error.cshtml.cs
@@ -7,7 +7,7 @@ namespace Microsoft.eShopWeb.Web.Pages;
 [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
 public class ErrorModel : PageModel
 {
-    public string RequestId { get; set; }
+    public string? RequestId { get; set; }
 
     public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
 

--- a/src/Web/SlugifyParameterTransformer.cs
+++ b/src/Web/SlugifyParameterTransformer.cs
@@ -5,7 +5,7 @@ namespace Microsoft.eShopWeb.Web;
 
 public class SlugifyParameterTransformer : IOutboundParameterTransformer
 {
-    public string TransformOutbound(object value)
+    public string? TransformOutbound(object value)
     {
         if (value == null) { return null; }
 

--- a/src/Web/ViewModels/Account/LoginViewModel.cs
+++ b/src/Web/ViewModels/Account/LoginViewModel.cs
@@ -6,11 +6,11 @@ public class LoginViewModel
 {
     [Required]
     [EmailAddress]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     [Required]
     [DataType(DataType.Password)]
-    public string Password { get; set; }
+    public string? Password { get; set; }
 
     [Display(Name = "Remember me?")]
     public bool RememberMe { get; set; }

--- a/src/Web/ViewModels/Account/LoginWith2faViewModel.cs
+++ b/src/Web/ViewModels/Account/LoginWith2faViewModel.cs
@@ -8,7 +8,7 @@ public class LoginWith2faViewModel
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]
     [Display(Name = "Authenticator code")]
-    public string TwoFactorCode { get; set; }
+    public string? TwoFactorCode { get; set; }
 
     [Display(Name = "Remember this machine")]
     public bool RememberMachine { get; set; }

--- a/src/Web/ViewModels/Account/RegisterViewModel.cs
+++ b/src/Web/ViewModels/Account/RegisterViewModel.cs
@@ -7,16 +7,16 @@ public class RegisterViewModel
     [Required]
     [EmailAddress]
     [Display(Name = "Email")]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "Password")]
-    public string Password { get; set; }
+    public string? Password { get; set; }
 
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
-    public string ConfirmPassword { get; set; }
+    public string? ConfirmPassword { get; set; }
 }

--- a/src/Web/ViewModels/Account/ResetPasswordViewModel.cs
+++ b/src/Web/ViewModels/Account/ResetPasswordViewModel.cs
@@ -6,17 +6,17 @@ public class ResetPasswordViewModel
 {
     [Required]
     [EmailAddress]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
-    public string Password { get; set; }
+    public string? Password { get; set; }
 
     [DataType(DataType.Password)]
     [Display(Name = "Confirm password")]
     [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
-    public string ConfirmPassword { get; set; }
+    public string? ConfirmPassword { get; set; }
 
-    public string Code { get; set; }
+    public string? Code { get; set; }
 }

--- a/src/Web/ViewModels/CatalogIndexViewModel.cs
+++ b/src/Web/ViewModels/CatalogIndexViewModel.cs
@@ -5,10 +5,10 @@ namespace Microsoft.eShopWeb.Web.ViewModels;
 
 public class CatalogIndexViewModel
 {
-    public List<CatalogItemViewModel> CatalogItems { get; set; }
-    public List<SelectListItem> Brands { get; set; }
-    public List<SelectListItem> Types { get; set; }
+    public List<CatalogItemViewModel>? CatalogItems { get; set; }
+    public List<SelectListItem>? Brands { get; set; }
+    public List<SelectListItem>? Types { get; set; }
     public int? BrandFilterApplied { get; set; }
     public int? TypesFilterApplied { get; set; }
-    public PaginationInfoViewModel PaginationInfo { get; set; }
+    public PaginationInfoViewModel? PaginationInfo { get; set; }
 }

--- a/src/Web/ViewModels/CatalogItemViewModel.cs
+++ b/src/Web/ViewModels/CatalogItemViewModel.cs
@@ -3,7 +3,7 @@
 public class CatalogItemViewModel
 {
     public int Id { get; set; }
-    public string Name { get; set; }
-    public string PictureUri { get; set; }
+    public string? Name { get; set; }
+    public string? PictureUri { get; set; }
     public decimal Price { get; set; }
 }

--- a/src/Web/ViewModels/File/FileViewModel.cs
+++ b/src/Web/ViewModels/File/FileViewModel.cs
@@ -2,7 +2,7 @@
 
 public class FileViewModel
 {
-    public string FileName { get; set; }
-    public string Url { get; set; }
-    public string DataBase64 { get; set; }
+    public string? FileName { get; set; }
+    public string? Url { get; set; }
+    public string? DataBase64 { get; set; }
 }

--- a/src/Web/ViewModels/Manage/ChangePasswordViewModel.cs
+++ b/src/Web/ViewModels/Manage/ChangePasswordViewModel.cs
@@ -7,18 +7,18 @@ public class ChangePasswordViewModel
     [Required]
     [DataType(DataType.Password)]
     [Display(Name = "Current password")]
-    public string OldPassword { get; set; }
+    public string? OldPassword { get; set; }
 
     [Required]
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
-    public string NewPassword { get; set; }
+    public string? NewPassword { get; set; }
 
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
-    public string ConfirmPassword { get; set; }
+    public string? ConfirmPassword { get; set; }
 
-    public string StatusMessage { get; set; }
+    public string? StatusMessage { get; set; }
 }

--- a/src/Web/ViewModels/Manage/EnableAuthenticatorViewModel.cs
+++ b/src/Web/ViewModels/Manage/EnableAuthenticatorViewModel.cs
@@ -10,11 +10,11 @@ public class EnableAuthenticatorViewModel
     [StringLength(7, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Text)]
     [Display(Name = "Verification Code")]
-    public string Code { get; set; }
+    public string? Code { get; set; }
 
     [BindNever]
-    public string SharedKey { get; set; }
+    public string? SharedKey { get; set; }
 
     [BindNever]
-    public string AuthenticatorUri { get; set; }
+    public string? AuthenticatorUri { get; set; }
 }

--- a/src/Web/ViewModels/Manage/ExternalLoginsViewModel.cs
+++ b/src/Web/ViewModels/Manage/ExternalLoginsViewModel.cs
@@ -6,8 +6,8 @@ namespace Microsoft.eShopWeb.Web.ViewModels.Manage;
 
 public class ExternalLoginsViewModel
 {
-    public IList<UserLoginInfo> CurrentLogins { get; set; }
-    public IList<AuthenticationScheme> OtherLogins { get; set; }
+    public IList<UserLoginInfo>? CurrentLogins { get; set; }
+    public IList<AuthenticationScheme>? OtherLogins { get; set; }
     public bool ShowRemoveButton { get; set; }
-    public string StatusMessage { get; set; }
+    public string? StatusMessage { get; set; }
 }

--- a/src/Web/ViewModels/Manage/IndexViewModel.cs
+++ b/src/Web/ViewModels/Manage/IndexViewModel.cs
@@ -10,11 +10,11 @@ public class IndexViewModel
 
     [Required]
     [EmailAddress]
-    public string Email { get; set; }
+    public string? Email { get; set; }
 
     [Phone]
     [Display(Name = "Phone number")]
-    public string PhoneNumber { get; set; }
+    public string? PhoneNumber { get; set; }
 
     public string? StatusMessage { get; set; }
 }

--- a/src/Web/ViewModels/Manage/RemoveLoginViewModel.cs
+++ b/src/Web/ViewModels/Manage/RemoveLoginViewModel.cs
@@ -2,6 +2,6 @@
 
 public class RemoveLoginViewModel
 {
-    public string LoginProvider { get; set; }
-    public string ProviderKey { get; set; }
+    public string? LoginProvider { get; set; }
+    public string? ProviderKey { get; set; }
 }

--- a/src/Web/ViewModels/Manage/SetPasswordViewModel.cs
+++ b/src/Web/ViewModels/Manage/SetPasswordViewModel.cs
@@ -8,12 +8,12 @@ public class SetPasswordViewModel
     [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
     [DataType(DataType.Password)]
     [Display(Name = "New password")]
-    public string NewPassword { get; set; }
+    public string? NewPassword { get; set; }
 
     [DataType(DataType.Password)]
     [Display(Name = "Confirm new password")]
     [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
-    public string ConfirmPassword { get; set; }
+    public string? ConfirmPassword { get; set; }
 
-    public string StatusMessage { get; set; }
+    public string? StatusMessage { get; set; }
 }

--- a/src/Web/ViewModels/Manage/ShowRecoveryCodesViewModel.cs
+++ b/src/Web/ViewModels/Manage/ShowRecoveryCodesViewModel.cs
@@ -2,6 +2,6 @@
 
 public class ShowRecoveryCodesViewModel
 {
-    public string[] RecoveryCodes { get; set; }
+    public string[]? RecoveryCodes { get; set; }
 }
 

--- a/src/Web/ViewModels/OrderItemViewModel.cs
+++ b/src/Web/ViewModels/OrderItemViewModel.cs
@@ -3,9 +3,9 @@
 public class OrderItemViewModel
 {
     public int ProductId { get; set; }
-    public string ProductName { get; set; }
+    public string? ProductName { get; set; }
     public decimal UnitPrice { get; set; }
     public decimal Discount => 0;
     public int Units { get; set; }
-    public string PictureUrl { get; set; }
+    public string? PictureUrl { get; set; }
 }

--- a/src/Web/ViewModels/OrderViewModel.cs
+++ b/src/Web/ViewModels/OrderViewModel.cs
@@ -12,6 +12,6 @@ public class OrderViewModel
     public DateTimeOffset OrderDate { get; set; }
     public decimal Total { get; set; }
     public string Status => DEFAULT_STATUS;
-    public Address ShippingAddress { get; set; }
+    public Address? ShippingAddress { get; set; }
     public List<OrderItemViewModel> OrderItems { get; set; } = new List<OrderItemViewModel>();
 }

--- a/src/Web/ViewModels/PaginationInfoViewModel.cs
+++ b/src/Web/ViewModels/PaginationInfoViewModel.cs
@@ -6,6 +6,6 @@ public class PaginationInfoViewModel
     public int ItemsPerPage { get; set; }
     public int ActualPage { get; set; }
     public int TotalPages { get; set; }
-    public string Previous { get; set; }
-    public string Next { get; set; }
+    public string? Previous { get; set; }
+    public string? Next { get; set; }
 }

--- a/src/Web/Views/Manage/ManageNavPages.cs
+++ b/src/Web/Views/Manage/ManageNavPages.cs
@@ -27,7 +27,7 @@ public static class ManageNavPages
     public static string PageNavClass(ViewContext viewContext, string page)
     {
         var activePage = viewContext.ViewData["ActivePage"] as string;
-        return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : null;
+        return string.Equals(activePage, page, StringComparison.OrdinalIgnoreCase) ? "active" : string.Empty;
     }
 
     public static void AddActivePage(this ViewDataDictionary viewData, string activePage) => viewData[ActivePageKey] = activePage;


### PR DESCRIPTION
**Push 1**- Fixed half of warnings having to do with allowing Null string objects.

- Code passes test suite and no abnormal function has yet been seen by addition of `string?` null option.