### PR TITLE
Update Dockerfile & launch to use .net 6.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM mcr.microsoft.com/dotnet/sdk:5.0
+FROM mcr.microsoft.com/dotnet/sdk:6.0
 
 # This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
 # property in devcontainer.json to use it. On Linux, the container user's GID/UIDs

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/Web/bin/Debug/net5.0/Web.dll",
+            "program": "${workspaceFolder}/src/Web/bin/Debug/net6.0/Web.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/Web",
             "stopAtEntry": false,


### PR DESCRIPTION
Minor configuration changes to fix the DevContainer Docker image and launch setting for .NET 6.0.