### PR TITLE
Fix dotnet-xunit lower bound warning

### DIFF
--- a/tests/FunctionalTests/FunctionalTests.csproj
+++ b/tests/FunctionalTests/FunctionalTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />     
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
-    <DotNetCliToolReference Include="dotnet-xunit" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In Visual Studio (solution: eShopOnWeb.sln starting project: Web), the following warning occurs, "Warning NU1604 Project dependency dotnet-xunit does not contain an inclusive lower bound. Include a lower bound in the dependency version to ensure consistent restore results." Adding version info to dotnet-xunit in project FunctionalTests resolves the issue.