### PR TITLE
Fixed build issue for PR Bump Microsoft.AspNetCore.Components.WebAssembly.Authentication from 7.0.5 to 7.0.10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,9 +18,9 @@
     <PackageVersion Include="BuildBundlerMinifier" Version="3.2.449" PrivateAssets="All" />
     <PackageVersion Include="FluentValidation" Version="11.7.1" />
     <PackageVersion Include="MediatR" Version="12.0.1" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.8" />
-    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.5" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="7.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.5" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="7.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.5" />


### PR DESCRIPTION
Fixed Build issue in [PR926 -Microsoft.AspNetCore.Components.WebAssembly.Authentication from 7.0.5 to 7.0.10](https://github.com/dotnet-architecture/eShopOnWeb/pull/926/files)