### PR TITLE
Remove the interface ISingleResultSpecification  usage from any specification

### DIFF
--- a/src/ApplicationCore/Specifications/BasketWithItemsSpecification.cs
+++ b/src/ApplicationCore/Specifications/BasketWithItemsSpecification.cs
@@ -3,7 +3,7 @@ using Microsoft.eShopWeb.ApplicationCore.Entities.BasketAggregate;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Specifications;
 
-public sealed class BasketWithItemsSpecification : Specification<Basket>, ISingleResultSpecification
+public sealed class BasketWithItemsSpecification : Specification<Basket>
 {
     public BasketWithItemsSpecification(int basketId)
     {

--- a/src/ApplicationCore/Specifications/OrderWithItemsByIdSpec.cs
+++ b/src/ApplicationCore/Specifications/OrderWithItemsByIdSpec.cs
@@ -3,7 +3,7 @@ using Microsoft.eShopWeb.ApplicationCore.Entities.OrderAggregate;
 
 namespace Microsoft.eShopWeb.ApplicationCore.Specifications;
 
-public class OrderWithItemsByIdSpec : Specification<Order>, ISingleResultSpecification
+public class OrderWithItemsByIdSpec : Specification<Order>
 {
     public OrderWithItemsByIdSpec(int orderId)
     {


### PR DESCRIPTION
ISingleResultSpecification is Obsolete
https://specification.ardalis.com/getting-started/faq.html